### PR TITLE
Update x402engine-mcp to 108 endpoints and 72 LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
-- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 50+ pay-per-call APIs for AI agents — image generation, code execution, transcription, crypto data, wallet analytics, IPFS, and more via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
+- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 38 pay-per-call APIs for AI agents — 15 LLMs (GPT-4o, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, Perplexity), image gen, code execution, TTS, transcription, crypto data, wallet analytics, web scraping, IPFS via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
 
 
 ### 💬 <a name="social"></a>Social

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
-- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 51 pay-per-call APIs for AI agents — 23 LLMs (GPT-5.2, GPT-4o, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, Perplexity, Kimi, MiniMax, GLM, Devstral), image/video generation, code execution, TTS, transcription, embeddings, crypto data, wallet analytics, ENS, tx simulation, web scraping, and IPFS via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
+- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - Connects agents to 108 x402 pay-per-call APIs: 72 LLMs plus image/video, web, code, crypto, audio, travel, and IPFS. Supports USDC on Base/Solana and USDm on MegaETH.
 
 
 ### 💬 <a name="social"></a>Social
@@ -174,4 +174,3 @@ Social MCP modules integrate with social platforms and protocols to enable ident
 - [sparfenyuk/mcp-telegram](https://github.com/sparfenyuk/mcp-telegram) - The server is a bridge between the Telegram API and the AI assistants and is based on the Model Context Protocol.
 - [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server) - Official Notion MCP Server.
 - [kukapay/twitter-username-changes-mcp](https://github.com/kukapay/twitter-username-changes-mcp) - An MCP server that tracks the historical changes of Twitter usernames.
-

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
+- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 50+ pay-per-call APIs for AI agents — image generation, code execution, transcription, crypto data, wallet analytics, IPFS, and more via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
 
 
 ### 💬 <a name="social"></a>Social

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
-- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 38 pay-per-call APIs for AI agents — 15 LLMs (GPT-4o, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, Perplexity), image gen, code execution, TTS, transcription, crypto data, wallet analytics, web scraping, IPFS via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
+- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp) - 51 pay-per-call APIs for AI agents — 23 LLMs (GPT-5.2, GPT-4o, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, Perplexity, Kimi, MiniMax, GLM, Devstral), image/video generation, code execution, TTS, transcription, embeddings, crypto data, wallet analytics, ENS, tx simulation, web scraping, and IPFS via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
 
 
 ### 💬 <a name="social"></a>Social


### PR DESCRIPTION
Updates the existing x402engine-mcp submission from 51 APIs and 23 LLMs to the live 108-endpoint gateway with 72 LLMs.

The gateway also provides image and video generation, web search and scraping, code execution, crypto and wallet data, transaction simulation, audio, travel, and IPFS. Payments use USDC on Base or Solana, or USDm on MegaETH.
