### PR TITLE
Add mcp-server-insumer (on-chain verification & attestation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
+- [douglasborthwick-crypto/mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer) - On-chain verification and attestation across 32 blockchains (EVM, Solana, XRPL). Returns ECDSA-signed boolean proofs of token balances, NFT ownership, EAS credentials, and wallet trust profiles. 25 tools. Used by DJD Agent Score (Coinbase x402).
 
 
 ### 💬 <a name="social"></a>Social


### PR DESCRIPTION
mcp-server-insumer fills a gap in this list: every existing Web3 MCP server focuses on raw data queries or transactions. This one focuses on verification — returning ECDSA-signed boolean attestations that any service can verify offline without re-querying the blockchain.

25 tools across 32 chains (30 EVM + Solana + XRPL). Published to npm and the Official MCP Registry.

- npm: https://www.npmjs.com/package/mcp-server-insumer
- GitHub: https://github.com/douglasborthwick-crypto/mcp-server-insumer