### PR TITLE
Add SkillFlow - AI Skills Marketplace Discovery MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Chain-RPC MCP modules interact with multiple blockchains by abstracting their RP
 - [mcpdotdirect/starknet-mcp-server](https://github.com/mcpdotdirect/starknet-mcp-server) - A comprehensive Model Context Protocol (MCP) server for the Starknet blockchain. This server provides AI agents with the ability to interact with Starknet networks, query blockchain data, manage wallets, and interact with smart contracts.
 - [RomThpt/mcp-xrpl](https://github.com/RomThpt/mcp-xrpl) - A comprehensive Model Context Protocol (MCP) server that provides blockchain services for the XRP Ledger ecosystem.
 - [hawkli-1994/go-sui-mcp](https://github.com/hawkli-1994/go-sui-mcp) - A Go-based management control plane server for Sui blockchain, providing MCP (Management Control Plane) tools to interact with local Sui client commands. This project integrates with Cursor IDE for enhanced development experience.
+* [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) - AI Skills Marketplace discovery server. Search, compare, and get installation instructions for curated MCP servers and AI agent tools.
 
 
 ### 💰 <a name="trading"></a>Trading


### PR DESCRIPTION
## Add SkillFlow MCP Server

**SkillFlow** is a curated AI Skills Marketplace that helps developers discover, compare, and integrate AI agent tools.

### Details
- **npm:** [`skillflow-mcp-server`](https://www.npmjs.com/package/skillflow-mcp-server) (v1.0.2)
- **GitHub:** [rafsilva85/skillflow-mcp-server](https://github.com/rafsilva85/skillflow-mcp-server)
- Published on the Official Anthropic MCP Registry and npm

### Installation
```bash
npx skillflow-mcp-server
```