### PR TITLE
Add Kaskad Protocol MCP to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 - [kukapay/uniswap-poolspy-mcp](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
 - [assetCLI/assetCLI-init](https://github.com/assetCLI/assetCLI-init) - assetCLI - Goldman Sachs for AI Agents. Winner of the Solana MCP AI Agent Competition. Vibe coding bonding curves, DEX & DAOs
 - [collinsezedike/wormhole-mcp](https://github.com/collinsezedike/wormhole-mcp) - A TypeScript/Node.js Model Context Protocol (MCP) server that enables automatic transfer of tokens across multiple blockchains using the Wormhole SDK.
+- [Kaskad-Lending/kaskad-mcp](https://github.com/Kaskad-Lending/kaskad-mcp) - First-party MCP server for Kaskad Protocol on Igra L2 (Kaspa). Enables AI agents to autonomously supply, borrow, repay, withdraw, and stake — plus read live markets, governance params, health factors, and emission state. 16 tools, full read + write access, native monitoring via checkHealthFactor.
 
 
 ### 📊 <a name="market-data"></a>Market Data


### PR DESCRIPTION
**Kaskad Protocol MCP** - the first first-party lending protocol MCP with full read + write access on a non-EVM L2 (Igra / Kaspa).

**Repo:** https://github.com/Kaskad-Lending/kaskad-mcp

**Why it fits:**
- 16 tools covering supply, borrow, repay, withdraw, stake, governance, emissions, health monitoring
- Full write access (not read-only analytics)
- Native checkHealthFactor with alert mode for agent cron loops
- Subgraph-backed historical data via getHistory
- llms.txt, obots.txt, kaskad.json live on testnet.kaskad.live for agent discoverability
- Compatible with Claude, OpenClaw, and any MCP client

Kaskad is live on the Igra Galleon testnet today.