### PR TITLE
Add Hive Intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Market Data MCP modules retrieve real-time market data from on-chain and off-cha
 - [CoinStatsHQ/coinstats-mcp](https://github.com/CoinStatsHQ/coinstats-mcp) - MCP Server for the CoinStats API. Provides access to cryptocurrency market data, portfolio tracking, and news.
 - [tony-42069/solana-mcp](https://github.com/tony-42069/solana-mcp) - A comprehensive Solana MCP (Model Context Protocol) server for analyzing memecoins, tracking trends, and providing AI-powered insights using cultural analysis and on-chain data.
 - [HubbleVision/hubble-ai-mcp](https://github.com/HubbleVision/hubble-ai-mcp) - Hubble is an AI-powered analytics tool that provides data analysis and visualization for Solana blockchain transactions with natural language queries.
-- [hive-intel/hive-crypto-mcp](https://github.com/hive-intel/hive-crypto-mcp) - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk across every major chain through a managed MCP, REST API, or CLI.
+- [hive-intel/hive-sdk](https://github.com/hive-intel/hive-sdk) - Managed crypto intelligence MCP for AI agents, with hosted and local stdio access across market data, DeFi, wallets, token risk, DEX flows, NFTs, Solana, infrastructure, and prediction markets.
 
 
 ### 🛠️ <a name="tool"></a>Tool
@@ -174,4 +174,3 @@ Social MCP modules integrate with social platforms and protocols to enable ident
 - [sparfenyuk/mcp-telegram](https://github.com/sparfenyuk/mcp-telegram) - The server is a bridge between the Telegram API and the AI assistants and is based on the Model Context Protocol.
 - [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server) - Official Notion MCP Server.
 - [kukapay/twitter-username-changes-mcp](https://github.com/kukapay/twitter-username-changes-mcp) - An MCP server that tracks the historical changes of Twitter usernames.
-

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Market Data MCP modules retrieve real-time market data from on-chain and off-cha
 - [CoinStatsHQ/coinstats-mcp](https://github.com/CoinStatsHQ/coinstats-mcp) - MCP Server for the CoinStats API. Provides access to cryptocurrency market data, portfolio tracking, and news.
 - [tony-42069/solana-mcp](https://github.com/tony-42069/solana-mcp) - A comprehensive Solana MCP (Model Context Protocol) server for analyzing memecoins, tracking trends, and providing AI-powered insights using cultural analysis and on-chain data.
 - [HubbleVision/hubble-ai-mcp](https://github.com/HubbleVision/hubble-ai-mcp) - Hubble is an AI-powered analytics tool that provides data analysis and visualization for Solana blockchain transactions with natural language queries.
+- [hive-intel/hive-crypto-mcp](https://github.com/hive-intel/hive-crypto-mcp) - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk across every major chain through a managed MCP, REST API, or CLI.
 
 
 ### 🛠️ <a name="tool"></a>Tool


### PR DESCRIPTION
Adds [Hive Intelligence](https://github.com/hive-intel/hive-sdk) to the **Market Data** section.

**What Hive is:** Hive Intelligence is a managed crypto intelligence MCP for AI agents. It supports hosted MCP and local stdio access through the public `hive-sdk` / `hive-intelligence` surfaces, with coverage across market data, DeFi, wallets, token risk, DEX flows, NFTs, Solana, infrastructure, and prediction markets.

**Why Market Data fits:** this section is for MCP modules that retrieve real-time market data from on-chain and off-chain sources through unified query interfaces. Hive fits as a broad managed crypto intelligence layer, while narrower entries in the section remain useful for provider-specific market data.

**Verification:**
- `git diff --check`
- `npx --yes markdown-link-check README.md` confirms the new Hive SDK link resolves; the full README check still reports three pre-existing unrelated dead links in the target repo.