### PR TITLE
docs: add twzrd-agent-intel to Tool section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract i
 - [CohumanSpace/digimon-engine](https://github.com/CohumanSpace/digimon-engine/tree/main/mcp) - Digimon Engine is an open-source gaming platform similar to Unreal Engine for AI gaming. It supports social and financial AI Agents, enabling immersive AI-native gameplay.
 - [noditlabs/nodit-mcp-server](https://github.com/noditlabs/nodit-mcp-server) - A Model Context Protocol (MCP) server that connects AI agents and developers to structured, context-ready blockchain data across multiple networks through Nodit's Web3 infrastructure.
 - [collinsezedike/metaplex-pnft-mcp](https://github.com/collinsezedike/metaplex-pnft-mcp/) - A TypeScript/Node.js Model Context Protocol (MCP) server that provides a structured and agent-friendly interface for the creation of programmable NFTs (pNFTs) using the Metaplex protocol on Solana.
+- [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - On-chain Solana agent trust scoring via x402 micropayments. Scores any Solana wallet by on-chain reputation, volume, and freshness. Free preflight + paid trust ($0.05) + market intel ($0.03). Hosted MCP at `https://intel.twzrd.xyz/mcp`. Also via PyPI `twzrd-agent-intel`.
 
 
 ### 💬 <a name="social"></a>Social


### PR DESCRIPTION
Add **TWZRD Agent Intel** — Solana agent trust scoring via x402 micropayments.

- Free tools: preflight readiness check, score lookup, top-agents leaderboard, receipt verification
- Paid tools: trust score ($0.05), market intel ($0.03), in USDC on Solana mainnet  
- Hosted MCP endpoint: `https://intel.twzrd.xyz/mcp` (streamable-http, no API key needed)
- PyPI: `pip install twzrd-agent-intel`
- Returns portable `twzrd.receipt.v5` (Ed25519-signed, offline-verifiable)
- Listed on: official MCP Registry, Smithery (quality 98), mcp.so, mcpservers.org

GitHub: https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel
