### PR TITLE
Add CoinGecko, DeFi Llama, and Etherscan MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Chain-RPC MCP modules interact with multiple blockchains by abstracting their RP
 - [Bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp) - MCP (Model Context Protocol) server for blockchain data interaction through the Bankless API.
 - [AbdelStark/bitcoin-mcp](https://github.com/AbdelStark/bitcoin-mcp) - An Model Context Protocol (MCP) server that enables AI models to interact with Bitcoin and Lightning Network, allowing them to generate keys, validate addresses, decode transactions, query the blockchain, and more.
 - [crazyrabbitLTC/mcp-etherscan-server](https://github.com/crazyrabbitLTC/mcp-etherscan-server) - An MCP (Model Context Protocol) server that provides Ethereum blockchain data tools via Etherscan's API.
+- [friendlygeorge/etherscan-mcp-server](https://github.com/friendlygeorge/etherscan-mcp-server) - Ethereum blockchain data: balances, transactions, contract ABIs, token transfers. 12 tools. Free tier. Install: `npx -y etherscan-mcp-server`.
 - [0xKoda/eth-mcp](https://github.com/0xKoda/eth-mcp) - An Model Context Protocol (MCP) server for interacting with Ethereum blockchain.
 - [AbdelStark/lightning-mcp](https://github.com/AbdelStark/lightning-mcp) - An Model Context Protocol (MCP) server that enables AI models to interact with Lightning Network, allowing them to pay invoices.
 - [marctheshark3/ergo-mcp](https://github.com/marctheshark3/ergo-mcp) - An Model Context Protocol (MCP) server for interacting with the Ergo blockchain.
@@ -106,6 +107,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 
 - [demcp/demcp-meson-mcp](https://github.com/demcp/demcp-meson-mcp) - A Meson cross-chain transaction MCP (Model Context Protocol) server implemented with Deno and TypeScript, helping users transfer assets conveniently between different blockchains.
 - [demcp/defillama-mcp](https://github.com/demcp/defillama-mcp) - DeFiLlama MCP is a powerful and flexible tool that provides a microservice-based API wrapper around the DeFi Llama ecosystem.
+- [friendlygeorge/defillama-mcp-server](https://github.com/friendlygeorge/defillama-mcp-server) - Free DeFi Llama MCP server with 10 tools for TVL, yields, protocol stats. No API key required. Install: `npx -y defillama-mcp-server`.
 - [kukapay/bridge-rates-mcp](https://github.com/kukapay/bridge-rates-mcp) - Delivering real-time cross-chain bridge rates and optimal transfer routes to onchain AI agents.
 - [kukapay/chainlink-feeds-mcp](https://github.com/kukapay/chainlink-feeds-mcp) -  Providing real-time access to Chainlink's decentralized on-chain price feeds.
 - [kukapay/defi-yields-mcp](https://github.com/kukapay/defi-yields-mcp) - An MCP server for AI agents to explore DeFi yield opportunities.
@@ -132,6 +134,7 @@ Market Data MCP modules retrieve real-time market data from on-chain and off-cha
 - [anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server) - Fetches real-time cryptocurrency prices, market cap, and volume data from CoinMarketCap.
 - [badger3000/okx-mcp-server](https://github.com/badger3000/okx-mcp-server) - This project creates a Model Context Protocol (MCP) server that fetches real-time cryptocurrency data from the OKX exchange.
 - [crazyrabbitLTC/mcp-coingecko-server](https://github.com/crazyrabbitLTC/mcp-coingecko-server) - An Model Context Protocol (MCP) server and OpenAI function calling service for interacting with the CoinGecko Pro API.
+- [friendlygeorge/coingecko-mcp-server](https://github.com/friendlygeorge/coingecko-mcp-server) - Free CoinGecko MCP server with 12 tools for crypto prices, market data, trending coins. No API key required. Install: `npx -y coingecko-mcp-server`.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.
 - [kukapay/cointelegraph-mcp](https://github.com/kukapay/cointelegraph-mcp) -  Providing real-time access to the latest news from Cointelegraph.
 - [kukapay/cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server) - Provide the latest cryptocurrency news to AI agents, powered by CryptoPanic.


### PR DESCRIPTION
Adds three free, open-source MCP servers for Web3 data:

- **[CoinGecko MCP Server](https://github.com/friendlygeorge/coingecko-mcp-server)** — Crypto prices, market data, trending coins. 12 tools. No API key required. Install: `npx -y coingecko-mcp-server`
- **[DeFi Llama MCP Server](https://github.com/friendlygeorge/defillama-mcp-server)** — TVL, yields, protocol stats, chain data. 10 tools. No API key required. Install: `npx -y defillama-mcp-server`
- **[Etherscan MCP Server](https://github.com/friendlygeorge/etherscan-mcp-server)** — Ethereum blockchain data: balances, transactions, contract ABIs. 12 tools. Free tier available. Install: `npx -y etherscan-mcp-server`

All TypeScript, MIT licensed, published on npm and GitHub.