### PR TITLE
Add friendlygeorge/coingecko-mcp-server to Market Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 
 - [demcp/demcp-meson-mcp](https://github.com/demcp/demcp-meson-mcp) - A Meson cross-chain transaction MCP (Model Context Protocol) server implemented with Deno and TypeScript, helping users transfer assets conveniently between different blockchains.
 - [demcp/defillama-mcp](https://github.com/demcp/defillama-mcp) - DeFiLlama MCP is a powerful and flexible tool that provides a microservice-based API wrapper around the DeFi Llama ecosystem.
+- [@supernova123/defillama-mcp-server](https://github.com/friendlygeorge/defillama-mcp-server) - DeFiLlama MCP server for DeFi data: TVL, yields, protocols, tokens, and historical charts. TypeScript, MIT license. 8 tools.
 - [kukapay/bridge-rates-mcp](https://github.com/kukapay/bridge-rates-mcp) - Delivering real-time cross-chain bridge rates and optimal transfer routes to onchain AI agents.
 - [kukapay/chainlink-feeds-mcp](https://github.com/kukapay/chainlink-feeds-mcp) -  Providing real-time access to Chainlink's decentralized on-chain price feeds.
 - [kukapay/defi-yields-mcp](https://github.com/kukapay/defi-yields-mcp) - An MCP server for AI agents to explore DeFi yield opportunities.
@@ -174,4 +175,3 @@ Social MCP modules integrate with social platforms and protocols to enable ident
 - [sparfenyuk/mcp-telegram](https://github.com/sparfenyuk/mcp-telegram) - The server is a bridge between the Telegram API and the AI assistants and is based on the Model Context Protocol.
 - [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server) - Official Notion MCP Server.
 - [kukapay/twitter-username-changes-mcp](https://github.com/kukapay/twitter-username-changes-mcp) - An MCP server that tracks the historical changes of Twitter usernames.
-

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Market Data MCP modules retrieve real-time market data from on-chain and off-cha
 - [kukapay/dune-analytics-mcp](https://github.com/kukapay/dune-analytics-mcp) - An MCP server that bridges Dune Analytics data to AI agents.
 - [anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server) - Fetches real-time cryptocurrency prices, market cap, and volume data from CoinMarketCap.
 - [badger3000/okx-mcp-server](https://github.com/badger3000/okx-mcp-server) - This project creates a Model Context Protocol (MCP) server that fetches real-time cryptocurrency data from the OKX exchange.
+- [friendlygeorge/coingecko-mcp-server](https://github.com/friendlygeorge/coingecko-mcp-server) - Free crypto market data via CoinGecko API. Search coins, get prices, market caps, trending data, historical charts, and global market stats. No API key required. 8 tools.
 - [crazyrabbitLTC/mcp-coingecko-server](https://github.com/crazyrabbitLTC/mcp-coingecko-server) - An Model Context Protocol (MCP) server and OpenAI function calling service for interacting with the CoinGecko Pro API.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.
 - [kukapay/cointelegraph-mcp](https://github.com/kukapay/cointelegraph-mcp) -  Providing real-time access to the latest news from Cointelegraph.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "friendlygeorge"
+  ]
+}


### PR DESCRIPTION
Adds [friendlygeorge/coingecko-mcp-server](https://github.com/friendlygeorge/coingecko-mcp-server) to the Market Data section.

**What it does:** Free crypto market data via CoinGecko API — prices, market caps, trending coins, historical charts, global market stats. No API key required. 8 tools.

**Install:** `npx -y coingecko-mcp-server`

**npm:** [@friendlygeorge/coingecko-mcp-server](https://www.npmjs.com/package/coingecko-mcp-server)

This is a free-tier alternative to the existing CoinGecko Pro entry, targeting users who don't have a Pro API key.