### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Market Data MCP modules retrieve real-time market data from on-chain and off-cha
 - [HubbleVision/hubble-ai-mcp](https://github.com/HubbleVision/hubble-ai-mcp) - Hubble is an AI-powered analytics tool that provides data analysis and visualization for Solana blockchain transactions with natural language queries.
 
 
+- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote x402 pay-per-call MCP capability chassis with 172 tools: DeFi yields, DEX quotes, crypto fear/greed, whale tracking, on-chain wallet analysis, Solana tx decoding, EVM token security, options chains, macro indicators. USDC on Base mainnet — no API key, no registration.
+
 ### 🛠️ <a name="tool"></a>Tool
 
 Tool MCP modules offer auxiliary utilities for Web3, supporting smart contract interactions, data processing, monitoring, and automation across decentralized systems.


### PR DESCRIPTION
## Add The Stall to Market Data section

[The Stall](https://github.com/thebrierfox/the-stall) is a remote x402 pay-per-call MCP server built on Base mainnet with 209 live capabilities.

**Why it belongs in this list:**
- Crypto/DeFi native — built on x402 protocol (USDC micropayments on Base)
- 209 tools including DeFi yields, DEX quotes, whale tracking, on-chain wallet analysis, Solana tx decoding, EVM token security, options chains, meme coin radar
- No API key — pay USDC per call, no registration required
- Real-time X/Twitter data via x402 proxy (`twitter-intel`)

**x402 Protocol:** HTTP 402 standard for USDC micropayments, native to Base/Coinbase ecosystem.

```json
{"mcpServers":{"the-stall":{"type":"streamable-http","url":"https://the-stall.intuitek.ai/mcp"}}}
```

git: a8ccfc4 | version: v4.63.1 | caps: 209

*Maintained by [IntuiTek¹](https://github.com/thebrierfox/the-stall)*