### PR TITLE
feat: The Stall — 210 pay-per-call AI capabilities via x402 (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 - [collinsezedike/wormhole-mcp](https://github.com/collinsezedike/wormhole-mcp) - A TypeScript/Node.js Model Context Protocol (MCP) server that enables automatic transfer of tokens across multiple blockchains using the Wormhole SDK.
 
 
-- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote MCP server with 183 pay-per-call tools spanning DeFi protocols, DEX analytics, yield farming, token security, and on-chain intelligence. Payments via x402/USDC — AI agents pay per call with no subscription.
+- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote MCP server with 191 pay-per-call tools spanning DeFi protocols, DEX analytics, yield farming, token security, and on-chain intelligence. Payments via x402/USDC — AI agents pay per call with no subscription.
 ### 📊 <a name="market-data"></a>Market Data
 
 Market Data MCP modules retrieve real-time market data from on-chain and off-chain sources via unified query interfaces.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 - [collinsezedike/wormhole-mcp](https://github.com/collinsezedike/wormhole-mcp) - A TypeScript/Node.js Model Context Protocol (MCP) server that enables automatic transfer of tokens across multiple blockchains using the Wormhole SDK.
 
 
+- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote MCP server with 183 pay-per-call tools spanning DeFi protocols, DEX analytics, yield farming, token security, and on-chain intelligence. Payments via x402/USDC — AI agents pay per call with no subscription.
 ### 📊 <a name="market-data"></a>Market Data
 
 Market Data MCP modules retrieve real-time market data from on-chain and off-chain sources via unified query interfaces.
@@ -173,4 +174,3 @@ Social MCP modules integrate with social platforms and protocols to enable ident
 - [sparfenyuk/mcp-telegram](https://github.com/sparfenyuk/mcp-telegram) - The server is a bridge between the Telegram API and the AI assistants and is based on the Model Context Protocol.
 - [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server) - Official Notion MCP Server.
 - [kukapay/twitter-username-changes-mcp](https://github.com/kukapay/twitter-username-changes-mcp) - An MCP server that tracks the historical changes of Twitter usernames.
-

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ DeFi MCP modules interact with DeFi protocols by abstracting their interfaces in
 - [collinsezedike/wormhole-mcp](https://github.com/collinsezedike/wormhole-mcp) - A TypeScript/Node.js Model Context Protocol (MCP) server that enables automatic transfer of tokens across multiple blockchains using the Wormhole SDK.
 
 
-- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote MCP server with 191 pay-per-call tools spanning DeFi protocols, DEX analytics, yield farming, token security, and on-chain intelligence. Payments via x402/USDC — AI agents pay per call with no subscription.
+- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) - A remote MCP server with 209 pay-per-call capabilities spanning DeFi protocols, DEX analytics, on-chain intelligence, market data, crypto news, and social signals. Payments via x402/USDC — AI agents pay per call with no subscription.
 ### 📊 <a name="market-data"></a>Market Data
 
 Market Data MCP modules retrieve real-time market data from on-chain and off-chain sources via unified query interfaces.


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, DEX analytics, on-chain intelligence, market data, crypto news, social signals, weather, aviation, clinical trials, and more.

**Why web3-relevant:**
- 30+ crypto/DeFi/on-chain capabilities (block-intel, chain-pulse, defi-state-pack, meme-radar, btc-game-theory, etc.)
- x402/USDC payment protocol — native Web3 monetization
- AI agents pay per call on Base network
- No subscription, no API key, no setup

Added to DeFi section as an x402-native data server.